### PR TITLE
Rails implementation of Quiz Master specifications

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -30,6 +30,8 @@ gem 'bootstrap-sass', '~> 3.3.4'
 
 gem 'haml-rails'
 
+gem 'humanize', '~> 1.1.0'
+
 group :development, :test do
   gem 'rspec-rails'
 end

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -31,6 +31,7 @@ gem 'bootstrap-sass', '~> 3.3.4'
 gem 'haml-rails'
 
 gem 'humanize', '~> 1.1.0'
+gem 'bootsy'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -34,4 +34,5 @@ gem 'humanize', '~> 1.1.0'
 
 group :development, :test do
   gem 'rspec-rails'
+  gem 'capybara', '~> 2.4.4'
 end

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -34,6 +34,10 @@ GEM
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    bootsy (2.1.0)
+      carrierwave (~> 0.10)
+      mini_magick (~> 4.0)
+      remotipart (~> 1.2)
     builder (3.2.2)
     capybara (2.4.4)
       mime-types (>= 1.16)
@@ -41,6 +45,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    carrierwave (0.10.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -77,6 +86,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
+    mini_magick (4.2.10)
     mini_portile (0.6.2)
     minitest (5.6.0)
     multi_json (1.11.0)
@@ -102,6 +112,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
+    remotipart (1.2.1)
     rspec-core (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.4)
@@ -159,6 +170,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass (~> 3.3.4)
+  bootsy
   capybara (~> 2.4.4)
   coffee-rails (~> 4.0.0)
   haml-rails

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -35,6 +35,12 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
     builder (3.2.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -145,12 +151,15 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bootstrap-sass (~> 3.3.4)
+  capybara (~> 2.4.4)
   coffee-rails (~> 4.0.0)
   haml-rails
   humanize (~> 1.1.0)

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
+    humanize (1.1.0)
     i18n (0.7.0)
     jbuilder (2.2.13)
       activesupport (>= 3.0.0, < 5)
@@ -152,6 +153,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.4)
   coffee-rails (~> 4.0.0)
   haml-rails
+  humanize (~> 1.1.0)
   jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.1.7)

--- a/rails/app/assets/javascripts/application.js.coffee
+++ b/rails/app/assets/javascripts/application.js.coffee
@@ -1,5 +1,6 @@
 #= require jquery
 #= require jquery_ujs
 #= require bootstrap
+#= require bootsy
 #= require turbolinks
 #= require_tree .

--- a/rails/app/assets/stylesheets/application.css.scss
+++ b/rails/app/assets/stylesheets/application.css.scss
@@ -10,7 +10,10 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require _bootstrap
+ *= require bootsy
  *= require_tree .
  *= require_self
  */
+
+@import "bootstrap-sprockets";
+@import "bootstrap";

--- a/rails/app/controllers/questions_controller.rb
+++ b/rails/app/controllers/questions_controller.rb
@@ -27,7 +27,8 @@ class QuestionsController < ApplicationController
   end
 
   def answer
-    # TODO
+    find_question
+    @correctAnswer = @question.is_correct?(params[:answer][:answer])
   end
 
   private

--- a/rails/app/models/question.rb
+++ b/rails/app/models/question.rb
@@ -4,7 +4,7 @@ class Question < ActiveRecord::Base
   validates_presence_of :answer
 
   def is_correct?(submission)
-    answer == submission
+    answer.squish == submission.squish
   end
 
 end

--- a/rails/app/models/question.rb
+++ b/rails/app/models/question.rb
@@ -4,7 +4,7 @@ class Question < ActiveRecord::Base
   validates_presence_of :answer
 
   def is_correct?(submission)
-    answer.squish == submission.squish
+    answer.squish.downcase == submission.squish.downcase
   end
 
 end

--- a/rails/app/models/question.rb
+++ b/rails/app/models/question.rb
@@ -4,7 +4,15 @@ class Question < ActiveRecord::Base
   validates_presence_of :answer
 
   def is_correct?(submission)
-    answer.squish.downcase == submission.squish.downcase
+    formatted_answer = answer.squish.downcase
+    formatted_submission = submission.squish.downcase
+    number_to_string(formatted_answer) == number_to_string(formatted_submission)
+  end
+
+  private
+
+  def number_to_string(string)
+    string.match(/^-?\d+$/) ? string.to_i.humanize : string
   end
 
 end

--- a/rails/app/views/questions/_form.html.haml
+++ b/rails/app/views/questions/_form.html.haml
@@ -7,7 +7,7 @@
 
   .form-group
     = f.label :question
-    = f.text_field :question, class: 'form-control'
+    = f.bootsy_area :question, class: 'form-control'
 
   .form-group
     = f.label :answer

--- a/rails/app/views/questions/_form.html.haml
+++ b/rails/app/views/questions/_form.html.haml
@@ -5,12 +5,12 @@
       - @question.errors.full_messages.each do |message|
         .message= message
 
-  .form-group
-    = f.label :question
+  .form-group{:class => "#{@question.errors[:question].empty? ? '' : 'has-error'}"}
+    .control-label= f.label :question
     = f.bootsy_area :question, class: 'form-control', rows: 15
 
-  .form-group
-    = f.label :answer
+  .form-group{:class => "#{@question.errors[:answer].empty? ? '' : 'has-error'}"}
+    .control-label= f.label :answer
     = f.text_field :answer, class: 'form-control'
 
   = f.submit nil, class: 'btn btn-primary'

--- a/rails/app/views/questions/_form.html.haml
+++ b/rails/app/views/questions/_form.html.haml
@@ -7,7 +7,7 @@
 
   .form-group
     = f.label :question
-    = f.bootsy_area :question, class: 'form-control'
+    = f.bootsy_area :question, class: 'form-control', rows: 15
 
   .form-group
     = f.label :answer

--- a/rails/app/views/questions/answer.html.haml
+++ b/rails/app/views/questions/answer.html.haml
@@ -1,0 +1,10 @@
+.container
+  %h1= @question.question
+
+  .well
+    - if @correctAnswer
+      %p Correct!
+      %p= "Answer: #{@question.answer}"
+    - else
+      %p Wrong!
+      %p= "The correct answer is: #{@question.answer}"

--- a/rails/app/views/questions/answer.html.haml
+++ b/rails/app/views/questions/answer.html.haml
@@ -13,5 +13,5 @@
   - else
     .panel.panel-danger
       .panel-heading
-        %h3.panel-title The answer you provided is wrong.
+        %h3.panel-title The answer you provided is incorrect.
       .panel-body= "The correct answer is: #{@question.answer}"

--- a/rails/app/views/questions/answer.html.haml
+++ b/rails/app/views/questions/answer.html.haml
@@ -1,10 +1,17 @@
 .container
-  %h1= @question.question
+  .panel.panel-default
+    .panel-heading
+      %h3.panel-title The question was:
+    .panel-body
+      = raw(@question.question)
 
-  .well
-    - if @correctAnswer
-      %p Correct!
-      %p= "Answer: #{@question.answer}"
-    - else
-      %p Wrong!
-      %p= "The correct answer is: #{@question.answer}"
+  - if @correctAnswer
+    .panel.panel-success
+      .panel-heading
+        %h3.panel-title The answer you provided is correct!
+      .panel-body= "Answer: #{@question.answer}"
+  - else
+    .panel.panel-danger
+      .panel-heading
+        %h3.panel-title The answer you provided is wrong.
+      .panel-body= "The correct answer is: #{@question.answer}"

--- a/rails/app/views/questions/index.html.haml
+++ b/rails/app/views/questions/index.html.haml
@@ -1,12 +1,10 @@
 .container
   %h1 Choose a question!
 
-  .well
-    %ul
-      - @questions.each do |question|
-        %li
-          = link_to truncate(strip_tags(question.question)), question
-          %span.small
-            (#{link_to "edit", edit_question_path(question)})
+  %table.table.table-hover
+    - @questions.each do |question|
+      %tr
+        %td= link_to truncate(strip_tags(question.question)), question
+        %td= link_to "edit", edit_question_path(question)
 
   = link_to "Add a new question", new_question_path

--- a/rails/app/views/questions/index.html.haml
+++ b/rails/app/views/questions/index.html.haml
@@ -5,7 +5,7 @@
     %ul
       - @questions.each do |question|
         %li
-          = link_to question.question, question
+          = link_to truncate(strip_tags(question.question)), question
           %span.small
             (#{link_to "edit", edit_question_path(question)})
 

--- a/rails/app/views/questions/show.html.haml
+++ b/rails/app/views/questions/show.html.haml
@@ -2,7 +2,7 @@
   %h1 Question time...
 
   .well
-    %p= @question.question
+    %p= raw(@question.question)
 
     = form_for :answer, url: answer_question_path(@question) do |f|
       .form-group

--- a/rails/app/views/questions/show.html.haml
+++ b/rails/app/views/questions/show.html.haml
@@ -1,11 +1,13 @@
 .container
-  %h1 Question time...
+  .page-header
+    %h1 Question time...
 
-  .well
-    %p= raw(@question.question)
+  .panel.panel-default
+    .panel-body
+      = raw(@question.question)
+    .panel-footer
+      = form_for :answer, url: answer_question_path(@question) do |f|
+        .form-group
+          = f.text_field :answer, class: 'form-control'
 
-    = form_for :answer, url: answer_question_path(@question) do |f|
-      .form-group
-        = f.text_field :answer, class: 'form-control'
-
-      = f.submit "Submit answer", class: 'btn btn-default'
+        = f.submit "Submit answer", class: 'btn btn-default'

--- a/rails/config/initializers/bootsy.rb
+++ b/rails/config/initializers/bootsy.rb
@@ -1,0 +1,69 @@
+# Use this setup block to configure all options available in Bootsy.
+Bootsy.setup do |config|
+  # Default editor options
+  #   You can also override them locally by passing an
+  #   editor_options hash to bootsy_area
+  # config.editor_options = {
+  #   font_styles: true,
+  #   emphasis: true,
+  #   lists: true,
+  #   html: false,
+  #   link: true,
+  #   image: true,
+  #   color: true
+  # }
+  #
+  # Image versions available
+  #  Possible values: :small, :medium, :large and/or :original
+  config.image_versions_available = [:small, :medium, :large, :original]
+  #
+  #
+  # SMALL IMAGES
+  #
+  # Width limit for small images
+  # config.small_image[:width] = 160
+  #
+  # Height limit for small images
+  # config.small_image[:height] = 160
+  #
+  #
+  # MEDIUM IMAGES
+  #
+  # Width limit for medium images
+  # config.medium_image[:width] = 360
+  #
+  # Height limit for medium images
+  # config.medium_image[:height] = 360
+  #
+  #
+  # LARGE IMAGES
+  #
+  # Width limit for large images
+  # config.large_image[:width] = 760
+  #
+  # Height limit for large images
+  # config.large_image[:height] = 760
+  #
+  #
+  # Whether user can destroy uploaded files
+  # config.allow_destroy = true
+  #
+  #
+  # Storage mode
+  #   You can change the sorage mode below from :file to :fog if you want
+  #   to use Amazon S3 and other cloud services. If you do that, please add
+  #   'fog' to your Gemfile and create and configure your credentials in an
+  #   initializer file, as described in Carrierwave's docs:
+  #   https://github.com/carrierwaveuploader/carrierwave#using-amazon-s3
+  # config.storage = :file
+  #
+  #
+  # Store directory (inside 'public') for storage = :file
+  #   BE CAREFUL! Changing this may break previously uploaded file paths!
+  # config.store_dir = 'uploads'
+  #
+  #
+  # Specify the controller to inherit from. Using ApplicationController
+  # allows you to perform authentication from within your app.
+  # config.base_controller = ActionController::Base
+end

--- a/rails/config/locales/bootsy.en.yml
+++ b/rails/config/locales/bootsy.en.yml
@@ -1,0 +1,30 @@
+en:
+  bootsy:
+    action:
+      refresh: Refresh
+      destroy: Delete
+      close: Close
+      load: Load
+      or: or
+      upload: Upload New Image
+      submit_upload: Go
+      enter_image_url: Enter a URL from the web...
+    image_gallery: Image Gallery
+    image:
+      s: Image
+      p: Images
+      size: Size
+      large: Large
+      medium: Medium
+      small: Small
+      original: Original
+      new: New image
+      confirm:
+        destroy: Are you sure you want to delete this image?
+      position:
+        left: Left
+        right: Right
+        inline: Inline
+    no_images_uploaded: There are currently no uploaded images.
+    js:
+      alert_unsaved: You have unsaved changes.

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Bootsy::Engine => '/bootsy', as: 'bootsy'
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/rails/db/migrate/20150826130408_create_bootsy_images.bootsy.rb
+++ b/rails/db/migrate/20150826130408_create_bootsy_images.bootsy.rb
@@ -1,0 +1,10 @@
+# This migration comes from bootsy (originally 20120624171333)
+class CreateBootsyImages < ActiveRecord::Migration
+  def change
+    create_table :bootsy_images do |t|
+      t.string :image_file
+      t.references :image_gallery
+      t.timestamps
+    end
+  end
+end

--- a/rails/db/migrate/20150826130409_create_bootsy_image_galleries.bootsy.rb
+++ b/rails/db/migrate/20150826130409_create_bootsy_image_galleries.bootsy.rb
@@ -1,0 +1,9 @@
+# This migration comes from bootsy (originally 20120628124845)
+class CreateBootsyImageGalleries < ActiveRecord::Migration
+  def change
+    create_table :bootsy_image_galleries do |t|
+      t.references :bootsy_resource, polymorphic: true
+      t.timestamps
+    end
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -11,7 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150421144709) do
+ActiveRecord::Schema.define(version: 20150826130409) do
+
+  create_table "bootsy_image_galleries", force: true do |t|
+    t.integer  "bootsy_resource_id"
+    t.string   "bootsy_resource_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "bootsy_images", force: true do |t|
+    t.string   "image_file"
+    t.integer  "image_gallery_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "questions", force: true do |t|
     t.string   "question"

--- a/rails/spec/controllers/questions_controller_spec.rb
+++ b/rails/spec/controllers/questions_controller_spec.rb
@@ -1,5 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe QuestionsController, :type => :controller do
-  it 'is missing specs'
+  describe "Get #index" do
+    it "responds successfully with an HTTP 200 status code" do
+      get :index
+      expect(response).to be_success
+      expect(response).to have_http_status(200)
+    end
+
+    it "renders the index template" do
+      get :index
+      expect(response).to render_template("index")
+    end
+
+    it "load all of the questions into @questions" do
+      question1 = Question.create(question: "Foo?", answer: "Bar")
+      question2 = Question.create(question: "Bar?", answer: "Baz")
+
+      get :index
+      expect(assigns(:questions)).to match_array([question1, question2])
+    end
+  end
 end

--- a/rails/spec/controllers/questions_controller_spec.rb
+++ b/rails/spec/controllers/questions_controller_spec.rb
@@ -21,4 +21,22 @@ RSpec.describe QuestionsController, :type => :controller do
       expect(assigns(:questions)).to match_array([question1, question2])
     end
   end
+
+  describe "Get #new" do
+    it "responds successfully with an HTTP 200 status code" do
+      get :new
+      expect(response).to be_success
+      expect(response).to have_http_status(200)
+    end
+
+    it "renders the new template" do
+      get :new
+      expect(response).to render_template("new")
+    end
+
+    it "creates a Question instance to use in the form" do
+      get :new
+      expect(assigns(:question)).to be_instance_of(Question)
+    end
+  end
 end

--- a/rails/spec/features/quiz_master_spec.rb
+++ b/rails/spec/features/quiz_master_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature 'Quiz Master', :type => :feature do
+  scenario 'User creates a new question' do
+    visit '/questions/new'
+
+    fill_in 'Question', :with => 'Who are you?'
+    fill_in 'Answer', :with => 'Your worst nightmare'
+
+    click_button 'Create Question'
+
+    expect(page).to have_content 'Question created successfully'
+  end
+end

--- a/rails/spec/features/quiz_master_spec.rb
+++ b/rails/spec/features/quiz_master_spec.rb
@@ -32,3 +32,21 @@ RSpec.feature 'Quiz Master', :type => :feature do
     expect(page).to have_content "Answer can't be blank"
   end
 end
+
+RSpec.feature 'Update question', :type => :feature do
+  before :each do
+    @question = Question.create(:question => 'What is the meaning of life?', :answer => "42")
+    @question.save
+  end
+
+  scenario 'user updates a question' do
+    visit(edit_question_path(@question))
+
+    fill_in 'Question', :with => 'Are you sure that is the meaning of life?'
+    fill_in 'Answer', :with => 'Yes'
+
+    click_button 'Update Question'
+
+    expect(page).to have_content "Question saved successfully"
+  end
+end

--- a/rails/spec/features/quiz_master_spec.rb
+++ b/rails/spec/features/quiz_master_spec.rb
@@ -11,4 +11,24 @@ RSpec.feature 'Quiz Master', :type => :feature do
 
     expect(page).to have_content 'Question created successfully'
   end
+
+  scenario 'User leaves Question field blank' do
+    visit '/questions/new'
+
+    fill_in 'Answer', :with => 'Answer without a question'
+
+    click_button 'Create Question'
+
+    expect(page).to have_content "Question can't be blank"
+  end
+
+  scenario 'User leaves Answer field blank' do
+    visit '/questions/new'
+
+    fill_in 'Question', :with => 'What is the meaning of life?'
+
+    click_button 'Create Question'
+
+    expect(page).to have_content "Answer can't be blank"
+  end
 end

--- a/rails/spec/features/user_answers_a_question_spec.rb
+++ b/rails/spec/features/user_answers_a_question_spec.rb
@@ -7,19 +7,19 @@ RSpec.feature 'User answers a question', :type => :feature do
     visit(question_path(@question))
   end
 
-  scenario 'user correctly answers the question' do
+  scenario 'correctly' do
     fill_in 'answer_answer', :with => 'sandals'
     click_button 'Submit answer'
 
-    expect(page).to have_content 'Correct!'
+    expect(page).to have_content 'The answer you provided is correct!'
     expect(page).to have_content "Answer: #{@question.answer}"
   end
 
-  scenario 'user incorrectly answers the question' do
+  scenario 'incorrectly' do
     fill_in 'answer_answer', :with => 'Cat'
     click_button 'Submit answer'
 
-    expect(page).to have_content 'Wrong!'
+    expect(page).to have_content 'The answer you provided is incorrect.'
     expect(page).to have_content "The correct answer is: #{@question.answer}"
   end
 end

--- a/rails/spec/features/user_answers_a_question_spec.rb
+++ b/rails/spec/features/user_answers_a_question_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature 'User answers a question', :type => :feature do
+  before :each do
+    @question = Question.create(:question => 'What is your favorite pet?', :answer => 'Sandals')
+    @question.save
+    visit(question_path(@question))
+  end
+
+  scenario 'user correctly answers the question' do
+    fill_in 'answer_answer', :with => 'sandals'
+    click_button 'Submit answer'
+
+    expect(page).to have_content 'Correct!'
+    expect(page).to have_content "Answer: #{@question.answer}"
+  end
+end

--- a/rails/spec/features/user_answers_a_question_spec.rb
+++ b/rails/spec/features/user_answers_a_question_spec.rb
@@ -14,4 +14,12 @@ RSpec.feature 'User answers a question', :type => :feature do
     expect(page).to have_content 'Correct!'
     expect(page).to have_content "Answer: #{@question.answer}"
   end
+
+  scenario 'user incorrectly answers the question' do
+    fill_in 'answer_answer', :with => 'Cat'
+    click_button 'Submit answer'
+
+    expect(page).to have_content 'Wrong!'
+    expect(page).to have_content "The correct answer is: #{@question.answer}"
+  end
 end

--- a/rails/spec/features/user_creates_a_question_spec.rb
+++ b/rails/spec/features/user_creates_a_question_spec.rb
@@ -33,20 +33,3 @@ RSpec.feature 'Quiz Master', :type => :feature do
   end
 end
 
-RSpec.feature 'Update question', :type => :feature do
-  before :each do
-    @question = Question.create(:question => 'What is the meaning of life?', :answer => "42")
-    @question.save
-  end
-
-  scenario 'user updates a question' do
-    visit(edit_question_path(@question))
-
-    fill_in 'Question', :with => 'Are you sure that is the meaning of life?'
-    fill_in 'Answer', :with => 'Yes'
-
-    click_button 'Update Question'
-
-    expect(page).to have_content "Question saved successfully"
-  end
-end

--- a/rails/spec/features/user_updates_a_question_spec.rb
+++ b/rails/spec/features/user_updates_a_question_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'Update question', :type => :feature do
+  before :each do
+    @question = Question.create(:question => 'What is the meaning of life?', :answer => "42")
+    @question.save
+  end
+
+  scenario 'user updates a question' do
+    visit(edit_question_path(@question))
+
+    fill_in 'Question', :with => 'Are you sure that is the meaning of life?'
+    fill_in 'Answer', :with => 'Yes'
+
+    click_button 'Update Question'
+
+    expect(page).to have_content "Question saved successfully"
+  end
+end

--- a/rails/spec/features/user_updates_a_question_spec.rb
+++ b/rails/spec/features/user_updates_a_question_spec.rb
@@ -4,16 +4,30 @@ RSpec.feature 'Update question', :type => :feature do
   before :each do
     @question = Question.create(:question => 'What is the meaning of life?', :answer => "42")
     @question.save
+    visit(edit_question_path(@question))
   end
 
   scenario 'user updates a question' do
-    visit(edit_question_path(@question))
-
     fill_in 'Question', :with => 'Are you sure that is the meaning of life?'
     fill_in 'Answer', :with => 'Yes'
-
     click_button 'Update Question'
 
     expect(page).to have_content "Question saved successfully"
+  end
+
+  scenario 'user leaves Question field blank' do
+    fill_in 'Question', :with => ''
+    fill_in 'Answer', :with => 'Answer without a question'
+    click_button 'Update Question'
+
+    expect(page).to have_content "Question can't be blank"
+  end
+
+  scenario 'user leaves Answer field blank' do
+    fill_in 'Question', :with => 'What is the meaning of life?'
+    fill_in 'Answer', :with => ''
+    click_button 'Update Question'
+
+    expect(page).to have_content "Answer can't be blank"
   end
 end


### PR DESCRIPTION
This is a series of commits to implement the specifications of the Rails version of Quiz Master. The following are addressed in this pull request and how they are implemented:

- There is no implementation for answering a question and knowing whether you got the answer right or wrong. Please add such implementation
  - Filled in the `answer` action of `questions_controller` to redirect the user to a new page where Quiz Master displays the question and indicates if the user got the answer right or wrong
- The Rspec tests currently fail. Please finish the model so that the tests pass
  - `is_correct?` method of the `Question` model is updated to ignore consecutive whitespace characters around and in between the answer string, ignore case and to recognise numbers as words
- The site's implementation is missing tests. Please provide either controller specs and/or feature specs to test the implementation
  - RSpec was used to create tests for `questions_controller` and capybara gem was added to implement feature specs for answering, creating and updating questions
- Currently the question text is merely plain text. Please add the ability for users to provide some simple formatting
  - [bootsy](https://github.com/volmer/bootsy) gem was used to provide a WYSIWYG editor for the   user when creating or updating a question


Other improvements outside the specification that are included in this PR are the following:
- Links to questions are displayed in the index page using a truncated version of the question string. This is to handle potentially very long questions.
- Questions are now displayed in a table with a separate column for the edit action link
- Prettified show and answer views by using Bootstrap panels
- Fields that have validation errors are displayed with red borders when creating or updating a question fails